### PR TITLE
fix typographical error in documentation

### DIFF
--- a/_docs/sign-offline.md
+++ b/_docs/sign-offline.md
@@ -8,7 +8,7 @@ To sign an offline transaction you will need a watch-only (zpub) wallet on a dev
 On the watch-only you build your transaction. This will generate a QR code that you will be able to scan or a file that you can export.
 
 On the wallet with the seed, you go to send → top options → sign transaction.
-Then scan the QR code or import the file. That's it the transaction is not signed and ready to be broadcasted.
+Then scan the QR code or import the file. That's it—the transaction is now signed and ready to be broadcasted.
 
 To import back to the online device, you just reserve the process and import the transaction from the watch-only wallet.
 


### PR DESCRIPTION
the original phrasing had the opposite meaning from which I think was intended