### PR TITLE
fix: Correct Lightning spelling

### DIFF
--- a/_includes/lightning.html
+++ b/_includes/lightning.html
@@ -75,7 +75,7 @@
                 <div class="uk-card uk-card-hover uk-card-body border-radius-medium">
                     <span class="uk-badge">3</span>
                     <h3 class="uk-card-title uk-margin">Start using Lightning</h3>
-                    <p>Once you send your transaction, it will <strong>require 3 confirmations</strong> before your balance appears on your Lightning wallet. Welcome to Lighting.</p>
+                    <p>Once you send your transaction, it will <strong>require 3 confirmations</strong> before your balance appears on your Lightning wallet. Welcome to Lightning.</p>
                 </div>
             </div>
       </div>

--- a/_site/lightning/index.html
+++ b/_site/lightning/index.html
@@ -296,7 +296,7 @@
                 <div class="uk-card uk-card-hover uk-card-body border-radius-medium">
                     <span class="uk-badge">3</span>
                     <h3 class="uk-card-title uk-margin">Start using Lightning</h3>
-                    <p>Once you send your transaction, it will <strong>require 3 confirmations</strong> before your balance appears on your Lightning wallet. Welcome to Lighting.</p>
+                    <p>Once you send your transaction, it will <strong>require 3 confirmations</strong> before your balance appears on your Lightning wallet. Welcome to Lightning.</p>
                 </div>
             </div>
       </div>

--- a/_site/oldsite-backup/lightning/index.html
+++ b/_site/oldsite-backup/lightning/index.html
@@ -249,7 +249,7 @@
             <div class="row align-items-center justify-content-end how-it-works">
               <div class="col-6 text-right">
                 <h5>Start using Lightning</h5>
-                <p>Once you send your transaction, it will require 3 confirmations before your funds appear on your Lightning wallet. Once it is done, you are welcome to the Lighting experience.</p>
+                <p>Once you send your transaction, it will require 3 confirmations before your funds appear on your Lightning wallet. Once it is done, you are welcome to the Lightning experience.</p>
               </div>
               <div class="col-2 text-center last">
                 <div class="circle">4</div>

--- a/oldsite-backup/lightning/index.html
+++ b/oldsite-backup/lightning/index.html
@@ -249,7 +249,7 @@
             <div class="row align-items-center justify-content-end how-it-works">
               <div class="col-6 text-right">
                 <h5>Start using Lightning</h5>
-                <p>Once you send your transaction, it will require 3 confirmations before your funds appear on your Lightning wallet. Once it is done, you are welcome to the Lighting experience.</p>
+                <p>Once you send your transaction, it will require 3 confirmations before your funds appear on your Lightning wallet. Once it is done, you are welcome to the Lightning experience.</p>
               </div>
               <div class="col-2 text-center last">
                 <div class="circle">4</div>


### PR DESCRIPTION
Just 4 typos fixed: "Light**n**ing" was missing the **n**.

![49229B61-4C61-4E52-97A8-B286D8D1CEFF](https://user-images.githubusercontent.com/20799436/138525184-5449b0ac-a234-4a6f-bfc1-34380729b4d3.png)
