### PR TITLE
email link

### DIFF
--- a/_site/docs/index.html
+++ b/_site/docs/index.html
@@ -255,7 +255,7 @@
                         <ul id="search-hero-results" class="uk-position-absolute uk-width-1-1 uk-list"></ul>
                     </div>
                     <br />
-                     <p class="uk-text-lead uk-text-center">or contact the team for any doubts <span class="uk-label">bluewallet@bluewallet.io</span></p>
+                     <p class="uk-text-lead uk-text-center">or contact the team for any doubts <a href="mailto:bluewallet@bluewallet.io"><span class="uk-label">bluewallet@bluewallet.io</span></a> </p>
 
                     <script>
                     SimpleJekyllSearch({


### PR DESCRIPTION
Browsing the site as a new customer and when I was on the support page I saw the email didn't allow you to mailto. Added an anchor tag to add that functionality. 

Not sure if y'all did that on purpose so figured I add it in and send it y'all way.

