### PR TITLE
Fix desktop wallet page copy and install FAQ

### DIFF
--- a/_faqs/desktop/10-install-mac.md
+++ b/_faqs/desktop/10-install-mac.md
@@ -3,4 +3,4 @@ title: How do I install BlueWallet on Mac?
 categories: [desktop]
 ---
 
-From the [Mac App Store](https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040), a [direct .dmg](https://github.com/BlueWallet/BlueWallet/releases), or [Homebrew](https://formulae.brew.sh/cask/bluewallet).
+From the [Mac App Store](https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040) or [Homebrew](https://formulae.brew.sh/cask/bluewallet).

--- a/_faqs/desktop/60-lightning-multisig.md
+++ b/_faqs/desktop/60-lightning-multisig.md
@@ -3,4 +3,4 @@ title: Does desktop support Lightning and multisig?
 categories: [desktop]
 ---
 
-Yes, the same wallet types as mobile: Lightning via your own LNDhub node, and Multisig Vaults, plus the formats listed on this page (BIP84/49/44, Electrum, legacy).
+Multisig vaults, yes. Lightning if you run your own LNDhub node.

--- a/_includes/desktop-wallet.html
+++ b/_includes/desktop-wallet.html
@@ -1,7 +1,7 @@
 <div class="uk-section">
    <div class="uk-container uk-text-center uk-animation-slide-bottom-medium">
       <h1 class="uk-heading-hero">BlueWallet for Mac</h1>
-      <a href="https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040" target="_blank" data-pirsch-event="Download" data-pirsch-meta-platform="macOS" data-pirsch-meta-location="Desktop Page">
+      <a class="uk-margin-medium-top" href="https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040" target="_blank" data-pirsch-event="Download" data-pirsch-meta-platform="macOS" data-pirsch-meta-location="Desktop Page">
         <img src="{{ site.uploads | absolute_url }}/mac-store-badge.svg" alt="download bitcoin wallet for desktop">
       </a>
       

--- a/_includes/desktop-wallet.html
+++ b/_includes/desktop-wallet.html
@@ -1,12 +1,11 @@
 <div class="uk-section">
    <div class="uk-container uk-text-center uk-animation-slide-bottom-medium">
-      <h2 class="uk-h2 uk-margin-remove-bottom uk-text-lead">BlueWallet for MacOS</h2>
-      <h1 class="uk-heading-hero uk-margin-remove-top">Desktop Wallet</h1>
+      <h1 class="uk-heading-hero">BlueWallet for Mac</h1>
       <a href="https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040" target="_blank" data-pirsch-event="Download" data-pirsch-meta-platform="macOS" data-pirsch-meta-location="Desktop Page">
         <img src="{{ site.uploads | absolute_url }}/mac-store-badge.svg" alt="download bitcoin wallet for desktop">
       </a>
       
-        <p class="uk-text-lead uk-margin-medium-bottom uk-margin-medium-top">Direct download available with <a href="https://github.com/BlueWallet/BlueWallet/releases" target="_blank" data-pirsch-event="Download" data-pirsch-meta-platform="GitHub" data-pirsch-meta-location="Desktop Page">.dmg</a> or <a href="https://formulae.brew.sh/cask/bluewallet" target="_blank">Homebrew</a></p>
+        <p class="uk-text-lead uk-margin-medium-bottom uk-margin-medium-top">Official macOS build. Your keys stay on your device. Get it from the <a href="https://apps.apple.com/app/bluewallet-bitcoin-wallet/id1376878040" target="_blank" data-pirsch-event="Download" data-pirsch-meta-platform="macOS" data-pirsch-meta-location="Desktop Page">Mac App Store</a> or <a href="https://formulae.brew.sh/cask/bluewallet" target="_blank">Homebrew</a>.</p>
       
       <div class="uk-animation-slide-bottom-medium">
       <img src="{{ site.uploads | absolute_url }}/desktop-bitcoin-wallet.png" alt="download bitcoin wallet for desktop">

--- a/desktop-bitcoin-wallet.md
+++ b/desktop-bitcoin-wallet.md
@@ -2,8 +2,8 @@
 layout: page
 width: expand
 permalink: /desktop-bitcoin-wallet/
-title: Desktop Bitcoin Wallet - Bitcoin and Lightning wallet for Desktop, macOS, Linux and Windows
-description: Desktop Bitcoin Wallet - Bitcoin and Lightning wallet for Desktop, macOS, Linux and Windows
+title: BlueWallet for Mac. Self-custody Bitcoin wallet for macOS
+description: Official BlueWallet for macOS. Mac App Store or Homebrew.
 cover: desktop.png
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Copy and metadata fix for `/desktop-bitcoin-wallet/`. No layout or styling changes beyond hero spacing.

## Changes

- **Title:** BlueWallet for Mac. Self-custody Bitcoin wallet for macOS
- **Meta description:** Official BlueWallet for macOS. Mac App Store or Homebrew.
- **H1:** BlueWallet for Mac
- **Lead:** Official macOS build. Your keys stay on your device. Get it from the Mac App Store or Homebrew.
- Removed duplicate macOS eyebrow above the H1
- Added `uk-margin-medium-top` on the Mac App Store badge link for spacing after eyebrow removal
- Install FAQ updated to Mac App Store or Homebrew only (no .dmg download path)
- Lightning/multisig FAQ answer: Multisig vaults, yes. Lightning if you run your own LNDhub node.

## Hero screenshot (~1280px)

[Desktop wallet hero](https://cursor.com/agents/bc-66d53feb-3724-4e1d-b746-988b96b8bea2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_wallet_hero_1280.png)

Built locally with `bundle exec jekyll build`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66d53feb-3724-4e1d-b746-988b96b8bea2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66d53feb-3724-4e1d-b746-988b96b8bea2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

