### PR TITLE
Remove Chrome card from the download page

### DIFF
--- a/_includes/download-page.html
+++ b/_includes/download-page.html
@@ -39,7 +39,7 @@
 
 <div class="uk-section download-platforms">
   <div class="uk-container">
-    <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-match uk-grid-medium" uk-grid>
+    <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-match uk-grid-medium" uk-grid>
       <div>
         <div class="uk-card uk-card-default uk-card-body uk-box-shadow-medium border-radius-medium border-light download-platform-card">
           <h3 class="uk-card-title">Android APK</h3>
@@ -61,24 +61,9 @@
           </ul>
         </div>
       </div>
-
-      <div>
-        <div class="uk-card uk-card-default uk-card-body uk-box-shadow-medium border-radius-medium border-light download-platform-card">
-          <h3 class="uk-card-title">Chrome</h3>
-          <p>BlueWallet Portfolio is watch-only. Add addresses or xpubs—no seeds, no sending.</p>
-          <ul class="uk-list uk-list-bullet download-platform-links">
-            <li><a href="{{ '/extension/' | relative_url }}">Portfolio extension</a>, side panel or full page</li>
-            {% assign cws_url = site.data.extension.chrome_web_store_url | default: "" | strip %}
-            {% if cws_url != "" %}
-            <li><a href="{{ cws_url }}" target="_blank" rel="noopener" data-pirsch-event="Download" data-pirsch-meta-platform="Chrome" data-pirsch-meta-location="Download Page">Chrome Web Store</a></li>
-            {% endif %}
-          </ul>
-        </div>
-      </div>
     </div>
 
-    {% assign cws_url = site.data.extension.chrome_web_store_url | default: "" | strip %}
-    <p class="download-sources-line uk-text-center">Only from this page, the App Store, Google Play,{% if cws_url != "" %} the Chrome Web Store,{% endif %} and github.com/BlueWallet.</p>
+    <p class="download-sources-line uk-text-center">Only from this page, the App Store, Google Play, and github.com/BlueWallet.</p>
   </div>
 </div>
 

--- a/download.md
+++ b/download.md
@@ -2,8 +2,8 @@
 layout: page
 width: expand
 permalink: /download/
-title: Download BlueWallet. Official iOS, Android, macOS and Chrome install
-description: Official download page for BlueWallet, the self-custody Bitcoin wallet. Install from the App Store, Google Play, GitHub releases, macOS, or the Chrome Web Store.
+title: Download BlueWallet. Official iOS, Android and macOS install
+description: Official download page for BlueWallet, the self-custody Bitcoin wallet. Install from the App Store, Google Play, GitHub releases, or macOS.
 cover: home.png
 ---
 


### PR DESCRIPTION
## Summary
- Take the Chrome / Portfolio extension block off `/download/` for now.
- Restore the two-column Android APK and macOS layout, and drop Chrome from the page title and trusted-sources line.

## Test plan
- [ ] Open `/download/` and confirm only Android APK and macOS cards are shown.
- [ ] Confirm `/extension/` still exists and is unchanged.


Made with [Cursor](https://cursor.com)